### PR TITLE
v0.3.1 - Temporarily disable '@typescript-eslint/no-explicit-any' lint check.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
     "prettier/prettier": "off",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-explicit-any": "off",
     "no-console": "off",
     "react/no-unescaped-entities": "off"
   }


### PR DESCRIPTION
PR title is self-explanatory.