### PR TITLE
v0.3.2 - Add Suspense boundary for analytics provider.

### DIFF
--- a/src/app/components/AnalyticsProvider.tsx
+++ b/src/app/components/AnalyticsProvider.tsx
@@ -1,14 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, Suspense } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { initGA, trackPageView } from '@/lib/analytics';
 
-export function AnalyticsProvider({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+function AnalyticsProviderInner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -26,5 +22,20 @@ export function AnalyticsProvider({
     }
   }, [pathname, searchParams]);
 
-  return <>{children}</>;
+  return null;
+}
+
+export function AnalyticsProvider({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <Suspense fallback={null}>
+        <AnalyticsProviderInner />
+      </Suspense>
+      {children}
+    </>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { Oxanium } from 'next/font/google';
 import localFont from "next/font/local";
 import { AnalyticsProvider } from '@/components/AnalyticsProvider';


### PR DESCRIPTION
## Problem
The production build was failing due to `useSearchParams()` not being wrapped in a Suspense boundary, causing a CSR bailout error during static page generation.

## Solution
- Split AnalyticsProvider into inner/outer components.
- Wrapped the component using `useSearchParams` in a Suspense boundary.
- Updated layout component to import Suspense from React.

## Testing
- Verified successful `npm run build`.
- Tested page interactions, layout, and form submissions.

## Related
- Fixes build error: "useSearchParams() should be wrapped in a suspense boundary".
- References Next.js documentation: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout