### PR TITLE
v0.3.5 - Resolve build error with analytics provider in static export.

### DIFF
--- a/src/app/components/AnalyticsProvider.tsx
+++ b/src/app/components/AnalyticsProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { initGA, trackPageView } from '@/lib/analytics';
 
 export function AnalyticsProvider({
@@ -10,7 +10,6 @@ export function AnalyticsProvider({
   children: React.ReactNode;
 }>) {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
 
   useEffect(() => {
     const initialize = async () => {
@@ -25,13 +24,9 @@ export function AnalyticsProvider({
 
   useEffect(() => {
     if (pathname) {
-      const url = searchParams.size > 0 
-        ? `${pathname}?${searchParams.toString()}`
-        : pathname;
-        
-      trackPageView(url);
+      trackPageView(pathname);
     }
-  }, [pathname, searchParams]);
+  }, [pathname]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
## Description
Fixed a build error that occurred during static export for GitHub Pages. The issue was caused by using `useSearchParams` in the AnalyticsProvider component, which isn't compatible with static site generation.

## Changes Made
- Removed `useSearchParams` to ensure compatibility with static export.